### PR TITLE
Added command to add a fighter to the ES index with Cobra

### DIFF
--- a/cmd/addFighter.go
+++ b/cmd/addFighter.go
@@ -16,7 +16,7 @@ var addfighterCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		client, err := elastic.NewClient(elastic.SetURL(viper.GetString("es_address")))
+		client, err := elastic.NewSimpleClient(elastic.SetURL(viper.GetString("es_address")))
 		if err != nil {
 			// Handle error
 			internal.Logger.Fatal().Err(err).Msg("failed to make new elastic search client")

--- a/cmd/addFighter.go
+++ b/cmd/addFighter.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/WSBenson/goku/internal"
+	"github.com/WSBenson/goku/internal/es"
+	"github.com/olivere/elastic/v7"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var addfighterCmd = &cobra.Command{
+	Use:   "addfighter",
+	Short: "Add your favorite Z fighters with one command",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+		client, err := elastic.NewClient(elastic.SetURL(viper.GetString("es_address")))
+		if err != nil {
+			// Handle error
+			internal.Logger.Fatal().Err(err).Msg("failed to make new elastic search client")
+		}
+
+		// calls AddF to add a fighter to the fighters index
+		es.AddF(ctx, client)
+	},
+}
+
+func init() {
+
+	rootCmd.AddCommand(addfighterCmd)
+	// flag to
+	addfighterCmd.Flags().StringP("fighter_name", "n", "Goku", "name of fighter to add to elasticsearch")
+	addfighterCmd.Flags().IntP("fighter_power", "p", 9001, "power level associated with that fighter")
+	// binds the port key to the pflag with viper
+	viper.BindPFlag("fighter_name", addfighterCmd.Flags().Lookup("fighter_name"))
+	viper.BindPFlag("fighter_power", addfighterCmd.Flags().Lookup("fighter_power"))
+}

--- a/cmd/addFighter.go
+++ b/cmd/addFighter.go
@@ -11,12 +11,12 @@ import (
 )
 
 var addfighterCmd = &cobra.Command{
-	Use:   "addfighter",
+	Use:   "addf",
 	Short: "Add your favorite Z fighters with one command",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		client, err := elastic.NewSimpleClient(elastic.SetURL(viper.GetString("es_address")))
+		client, err := elastic.NewSimpleClient(elastic.SetURL(viper.GetString("addr")))
 		if err != nil {
 			// Handle error
 			internal.Logger.Fatal().Err(err).Msg("failed to make new elastic search client")
@@ -31,9 +31,9 @@ func init() {
 
 	rootCmd.AddCommand(addfighterCmd)
 	// flag to
-	addfighterCmd.Flags().StringP("fighter_name", "n", "Goku", "name of fighter to add to elasticsearch")
-	addfighterCmd.Flags().IntP("fighter_power", "p", 9001, "power level associated with that fighter")
+	addfighterCmd.Flags().StringP("name", "n", "Goku", "name of fighter to add to elasticsearch")
+	addfighterCmd.Flags().IntP("level", "l", 9001, "power level associated with that fighter")
 	// binds the port key to the pflag with viper
-	viper.BindPFlag("fighter_name", addfighterCmd.Flags().Lookup("fighter_name"))
-	viper.BindPFlag("fighter_power", addfighterCmd.Flags().Lookup("fighter_power"))
+	viper.BindPFlag("name", addfighterCmd.Flags().Lookup("name"))
+	viper.BindPFlag("level", addfighterCmd.Flags().Lookup("level"))
 }

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (

--- a/cmd/es.go
+++ b/cmd/es.go
@@ -15,8 +15,8 @@ var elasticCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 
-		address := viper.GetString("es_address")
-		mapping := viper.GetString("es_mapping_file")
+		address := viper.GetString("addr")
+		mapping := viper.GetString("map")
 		es.ElasticClient(ctx, address, mapping)
 	},
 }
@@ -25,9 +25,9 @@ func init() {
 
 	rootCmd.AddCommand(elasticCmd)
 	// flag to
-	elasticCmd.Flags().StringP("es_address", "a", "http://localhost:9200", "url for Elasticsearch server")
-	elasticCmd.Flags().StringP("es_mapping_file", "m", "./mapping/mapping.json", "location for es mapping file")
+	elasticCmd.Flags().StringP("addr", "a", "http://localhost:9200", "address for Elasticsearch server")
+	elasticCmd.Flags().StringP("map", "m", "./mapping/mapping.json", "filepath to mapping.json for fighter index")
 	// binds the port key to the pflag with viper
-	viper.BindPFlag("es_address", elasticCmd.Flags().Lookup("es_address"))
-	viper.BindPFlag("es_mapping_file", elasticCmd.Flags().Lookup("es_mapping_file"))
+	viper.BindPFlag("addr", elasticCmd.Flags().Lookup("addr"))
+	viper.BindPFlag("map", elasticCmd.Flags().Lookup("map"))
 }

--- a/cmd/es.go
+++ b/cmd/es.go
@@ -16,7 +16,8 @@ var elasticCmd = &cobra.Command{
 		ctx := context.Background()
 
 		address := viper.GetString("es_address")
-		es.ElasticClient(ctx, address)
+		mapping := viper.GetString("es_mapping_file")
+		es.ElasticClient(ctx, address, mapping)
 	},
 }
 
@@ -24,8 +25,8 @@ func init() {
 
 	rootCmd.AddCommand(elasticCmd)
 	// flag to
-	elasticCmd.Flags().StringP("es_address", "a", "localhost:9200", "url for Elasticsearch server")
-	elasticCmd.Flags().StringP("es_mapping_file", "m", "./etc/mapping.json", "location for es mapping file")
+	elasticCmd.Flags().StringP("es_address", "a", "http://localhost:9200", "url for Elasticsearch server")
+	elasticCmd.Flags().StringP("es_mapping_file", "m", "./mapping/mapping.json", "location for es mapping file")
 	// binds the port key to the pflag with viper
 	viper.BindPFlag("es_address", elasticCmd.Flags().Lookup("es_address"))
 	viper.BindPFlag("es_mapping_file", elasticCmd.Flags().Lookup("es_mapping_file"))

--- a/cmd/es.go
+++ b/cmd/es.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (
@@ -30,7 +15,6 @@ var elasticCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 
-		// port := viper.GetString("port")
 		address := viper.GetString("es_address")
 		es.ElasticClient(ctx, address)
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 Willem Benson
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package cmd
 
 import (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       - "3000:3000"
     environment: 
       - PORT=3000
-      - ES_ADDRESS=http://es:9200
-      - ES_MAPPING_FILE=/etc/mapping.json
+      - ADDR=http://es:9200
+      - MAP=/etc/mapping.json
     depends_on: 
       - es
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment: 
       - PORT=3000
       - ES_ADDRESS=http://es:9200
-      - ES_MAPPING_FILE=./etc/mapping.json
+      - ES_MAPPING_FILE=/etc/mapping.json
     depends_on: 
       - es
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,8 @@ module github.com/WSBenson/goku
 go 1.14
 
 require (
-	github.com/fortytw2/leaktest v1.3.0 // indirect
-	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/olivere/elastic v6.2.33+incompatible
+	github.com/olivere/elastic/v7 v7.0.17
 	github.com/rs/zerolog v1.19.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.31.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -50,11 +51,13 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
@@ -66,6 +69,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
+github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -102,6 +107,7 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -140,14 +146,17 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/olivere/elastic v6.2.33+incompatible h1:SRPB2w2OhJ7iULftDEHsNPRoL2GLREqPMRalVmbZaEw=
-github.com/olivere/elastic v6.2.33+incompatible/go.mod h1:J+q1zQJTgAz9woqsbVRqGeB5G1iqDKVBWLNSYW8yfJ8=
+github.com/olivere/elastic/v7 v7.0.17 h1:VMHAc164MH85MIOyyyL6AAzIDixsdjIdAfmKotxNxyQ=
+github.com/olivere/elastic/v7 v7.0.17/go.mod h1:sd6x2HP229aT2+U2261gUUMCD4RVf/Nsso8HxSgcjDs=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -172,8 +181,12 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.1.0 h1:MkTeG1DMwsrdH7QtLXy5W+fUxWq+vmb6cLmyJ7aRtF0=
+github.com/smartystreets/assertions v1.1.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
+github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/gunit v1.3.4/go.mod h1:ZjM1ozSIMJlAz/ay4SG8PeKF00ckUp+zMHZXV9/bvak=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
@@ -194,6 +207,9 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -203,6 +219,7 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -244,6 +261,7 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -291,6 +309,8 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,1 +1,6 @@
 package app
+
+type Fighter struct {
+	Name  string `json:"name"`
+	Power int    `json:"power"`
+}

--- a/internal/app/handle.go
+++ b/internal/app/handle.go
@@ -9,12 +9,7 @@ import (
 )
 
 type fighters struct {
-	Fighters []fighter `json:"fighters"`
-}
-
-type fighter struct {
-	Name  string `json:"name"`
-	Power int    `json:"power"`
+	Fighters []Fighter `json:"fighters"`
 }
 
 // struct to hold the new concatination of the user's name

--- a/internal/app/logic.go
+++ b/internal/app/logic.go
@@ -24,7 +24,7 @@ func gokuPOSTCases(fs fighters) string {
 
 // The evaluatePowerLvl function handles the case where one fighter is passed to the server.
 // It will return a string that evaluates whether this fighter's power level is over 9000
-func evaluatePowerLvl(f fighter) string {
+func evaluatePowerLvl(f Fighter) string {
 	if f.Power > 9000 {
 		return "The scouter says " + f.Name + "'s power level is over 9000! You better start running."
 	} else if f.Power < 206 {
@@ -36,7 +36,7 @@ func evaluatePowerLvl(f fighter) string {
 
 // The compareTwoPowers funcion handles the case where two fighters are passed to the server.
 // It will return a string that compares these two fighters' power levels (who is stronger).
-func compareTwoPowers(f fighter, f1 fighter) string {
+func compareTwoPowers(f Fighter, f1 Fighter) string {
 	if f.Power == f1.Power && f.Power < 206 && f1.Power < 206 {
 		return f.Name + " and " + f1.Name + " are equally trash, they better fuse or something."
 	} else if f.Power < 206 && f1.Power < 206 {

--- a/internal/es/addf.go
+++ b/internal/es/addf.go
@@ -1,0 +1,107 @@
+package es
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/WSBenson/goku/internal"
+	"github.com/WSBenson/goku/internal/app"
+	"github.com/olivere/elastic/v7"
+	"github.com/spf13/viper"
+)
+
+// AddF ...
+func AddF(ctx context.Context, client *elastic.Client) { //, fighter1 app.Fighter) {
+	name := viper.GetString("fighter_name")
+	power := viper.GetInt("fighter_power")
+
+	f := app.Fighter{Name: name, Power: power}
+
+	// Use the IndexExists service to check if the specified fighter index exists before adding it.
+	exists, err := client.IndexExists("fighters").Do(ctx)
+	if err != nil {
+		// Handle error
+		internal.Logger.Fatal().Err(err).Msg("failed to check if fighters index exists")
+	}
+	if !exists {
+		internal.Logger.Error().Msg("failed to find fighters client")
+		return
+	}
+
+	// Index a fighter (using JSON serialization)
+	put1, err := client.Index().Index("fighters").Id(hashFighter(f)).BodyJson(f).Do(ctx)
+	if err != nil {
+		// Handle error
+		internal.Logger.Fatal().Msg(err.Error())
+	}
+	internal.Logger.Info().Msgf("Indexed fighter %s to index %s, type %s\n", put1.Id, put1.Index, put1.Type)
+
+	// Get fighter with specified ID
+	get1, err := client.Get().
+		Index("fighters").
+		Id(hashFighter(f)).
+		Do(ctx)
+	if err != nil {
+		// Handle error
+		internal.Logger.Fatal().Err(err).Msg("law gen ki de")
+	}
+	if get1.Found {
+		internal.Logger.Info().Msgf("Got document %s in version %d from index %s, type %s\n", get1.Id, get1.Version, get1.Index, get1.Type)
+	}
+
+	// Flush to make sure the documents got written.
+	_, err = client.Flush().Index("fighters").Do(ctx)
+	if err != nil {
+		internal.Logger.Fatal().Err(err).Msg("failed to flush to elastic search")
+	}
+
+	// Search with a term query
+	termQuery := elastic.NewTermQuery("name", f.Name)
+	searchResult, err := client.Search().
+		Index("fighters").  // search in index "fighters"
+		Query(termQuery).   // specify the query
+		Sort("name", true). // sort by "user" field, ascending
+		From(0).Size(10).   // take documents 0-9
+		Pretty(true).       // pretty print request and response JSON
+		Do(ctx)             // execute
+	if err != nil {
+		// Handle error
+		internal.Logger.Fatal().Err(err).Msg("failed to search")
+	}
+
+	// searchResult is of type SearchResult and returns hits, suggestions,
+	// and all kinds of other information from Elasticsearch.
+	fmt.Printf("Query took %d milliseconds\n", searchResult.TookInMillis)
+
+	// Each is a convenience function that iterates over hits in a search result.
+	// It makes sure you don't need to check for nil values in the response.
+	// However, it ignores errors in serialization. If you want full control
+	// over iterating the hits, see below.
+	var ftyp app.Fighter
+	internal.Logger.Info().Msgf("Got hits %v", searchResult.Hits.Hits)
+	for _, item := range searchResult.Each(reflect.TypeOf(ftyp)) {
+		if t, ok := item.(app.Fighter); ok {
+			internal.Logger.Info().Msgf("Fighter: %s, with a power level of %d\n", t.Name, t.Power)
+		}
+	}
+	// TotalHits is another convenience function that works even when something goes wrong.
+	internal.Logger.Info().Msgf("Found a total of %d fighters\n", searchResult.TotalHits())
+}
+
+// hashFighter is a function for hashing the name of a fighter with sha256
+// This hashed name is used for the fighter's Id.
+func hashFighter(f app.Fighter) string {
+	b, err := json.Marshal(f)
+	if err != nil {
+		internal.Logger.Fatal().Err(err).Msg("failed to marshal for hashing")
+	}
+
+	hasher := sha256.New()
+	hasher.Write(b)
+
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/internal/es/addf.go
+++ b/internal/es/addf.go
@@ -16,8 +16,8 @@ import (
 
 // AddF ...
 func AddF(ctx context.Context, client *elastic.Client) { //, fighter1 app.Fighter) {
-	name := viper.GetString("fighter_name")
-	power := viper.GetInt("fighter_power")
+	name := viper.GetString("name")
+	power := viper.GetInt("level")
 
 	f := app.Fighter{Name: name, Power: power}
 

--- a/internal/es/es.go
+++ b/internal/es/es.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/WSBenson/goku/internal"
-	"github.com/olivere/elastic"
+	"github.com/olivere/elastic/v7"
 	"github.com/spf13/viper"
 )
 
@@ -20,10 +20,10 @@ import (
 // 	elasAddSearch(ctx, client, fighter)
 // }
 
-// the ElasticClient function creates an elastic search client and
+// ElasticClient ... creates an elastic search client and
 // adds an index named fighters that will use the mapping variable to set
 // the layout of its body if it doesn't already exist.
-func ElasticClient(ctx context.Context, address string) *elastic.Client {
+func ElasticClient(ctx context.Context, address string) {
 	// Reads from the mapping.json file to get the mapping variable
 	b, err := ioutil.ReadFile(viper.GetString("es_mapping_file"))
 	if err != nil {
@@ -61,8 +61,10 @@ func ElasticClient(ctx context.Context, address string) *elastic.Client {
 			internal.Logger.Fatal().Err(err).Msg("failed to create new elastic search index")
 		}
 		if !createIndex.Acknowledged {
+			internal.Logger.Error().Msg("elasticsearch failed to acknowledge index creation")
 			// Not acknowledged
 		}
+		internal.Logger.Info().Msg("successfully created elasticsearch index")
 	}
-	return client
+
 }

--- a/internal/es/es.go
+++ b/internal/es/es.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/WSBenson/goku/internal"
 	"github.com/olivere/elastic/v7"
-	"github.com/spf13/viper"
 )
 
 //client :=
@@ -23,9 +22,10 @@ import (
 // ElasticClient ... creates an elastic search client and
 // adds an index named fighters that will use the mapping variable to set
 // the layout of its body if it doesn't already exist.
-func ElasticClient(ctx context.Context, address string) {
+func ElasticClient(ctx context.Context, address, mappingPath string) {
+	internal.Logger.Debug().Msgf(address, mappingPath)
 	// Reads from the mapping.json file to get the mapping variable
-	b, err := ioutil.ReadFile(viper.GetString("es_mapping_file"))
+	b, err := ioutil.ReadFile(mappingPath)
 	if err != nil {
 		internal.Logger.Fatal().Err(err).Msg("failed to retrieve es mapping")
 	}
@@ -40,7 +40,7 @@ func ElasticClient(ctx context.Context, address string) {
 
 	// Obtain a client and connect to the default Elasticsearch installation
 	// on localhost:9200.
-	client, err := elastic.NewClient(elastic.SetURL(address))
+	client, err := elastic.NewSimpleClient(elastic.SetURL(address))
 	if err != nil {
 		// Handle error
 		internal.Logger.Fatal().Err(err).Msg("failed to make new elastic search client")
@@ -55,7 +55,7 @@ func ElasticClient(ctx context.Context, address string) {
 	// If that index doesn't already exist
 	if !exists {
 		// Create that fighters index using the mapping variable to specify the layout of the index.
-		createIndex, err := client.CreateIndex("fighters").BodyString(mapping).Do(ctx)
+		createIndex, err := client.CreateIndex("fighters").BodyJson(mapping).Do(ctx)
 		if err != nil {
 			// Handle error
 			internal.Logger.Fatal().Err(err).Msg("failed to create new elastic search index")


### PR DESCRIPTION
This command can use the flags -n and -p to specify whatever name and power for your fighter you want to add.

By default the command "goku addfighter" will add a fighter with the name goku and a power level of 9001. NOTE: Make sure you run the "goku es" command first so it creates the client and index first.

As of right now, only one fighter can be stored in the elastic search index at a time so this is a known bug. I think I know the issue and will be working on fixing that tomorrow.